### PR TITLE
Fix for server version in addorUpdateEvent method

### DIFF
--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -218,7 +218,7 @@ public class EventService {
 		Event existingEvent = findById(event.getId());
 		if (existingEvent != null) {
 			event.setDateEdited(DateTime.now());
-			event.setServerVersion(null);
+			event.setServerVersion(event.getServerVersion());
 			event.setRevision(existingEvent.getRevision());
 			allEvents.update(event);
 			


### PR DESCRIPTION
Due to server version forcefully set to null in addorUpdateEvent method, clients were not being fetched in new devices through rest/event/sync (Post) api because when null is found in database then getEventsAndClients method in EventResource (opensrp-server-web) failed to fetch clientIds where server version field is set to null. 