### PR TITLE
Allow update of Task status even for older server Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>1.3.6-SNAPSHOT</version>
+	<version>1.3.7-SNAPSHOT</version>
 
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>

--- a/src/main/java/org/opensrp/service/TaskService.java
+++ b/src/main/java/org/opensrp/service/TaskService.java
@@ -123,19 +123,12 @@ public class TaskService {
 			try {
 				Task.TaskStatus status = fromString(taskUpdate.getStatus());
 				if (task != null && status != null) {
-					if (taskUpdate.getServerVersion() >= task.getServerVersion()) {
 						task.setBusinessStatus(taskUpdate.getBusinessStatus());
 						task.setStatus(status);
 						task.setLastModified(new DateTime());
 						task.setServerVersion(null);
 						taskRepository.update(task);
 						updatedTaskIds.add(task.getIdentifier());
-					} else {
-						logger.info("Ignoring update of task status for " + task.getIdentifier()
-								+ " task on server is more recent");
-						// mark task as updated so that client does not try to sync it again
-						updatedTaskIds.add(task.getIdentifier());
-					}
 				}
 			} catch (Exception e) {
 				logger.error(e.getMessage(), e);

--- a/src/test/java/org/opensrp/service/TaskServiceTest.java
+++ b/src/test/java/org/opensrp/service/TaskServiceTest.java
@@ -185,6 +185,7 @@ public class TaskServiceTest {
 		updates.add(taskUpdate);
 		when(taskRepository.get("tsk11231jh22")).thenReturn(task);
 		taskService.updateTaskStatus(updates);
+		assertEquals(now, taskUpdate.getServerVersion().longValue());
 
 		ArgumentCaptor<Task> argumentCaptor = ArgumentCaptor.forClass(Task.class);
 		verify(taskRepository).update(argumentCaptor.capture());


### PR DESCRIPTION
Resolves #133 and https://github.com/OpenSRP/opensrp-client-reveal/issues/629