### PR TITLE
Upgrade server common

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.0.0-alpha2-SNAPSHOT</version>
+	<version>2.0.0-alpha3-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>http://github.com/OpenSRP/opensrp-server-core</url>
@@ -22,7 +22,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<nexus-staging-maven-plugin.version>1.5.1</nexus-staging-maven-plugin.version>
 
-		<opensrp.common.version>2.0.0-alpha1-SNAPSHOT</opensrp.common.version>
+		<opensrp.common.version>2.0.0-alpha2-SNAPSHOT</opensrp.common.version>
 		<opensrp.api.version>1.0.1</opensrp.api.version>
 		<opensrp.interface.version>1.0.1</opensrp.interface.version>
 		<jackson.version>2.10.2</jackson.version>
@@ -159,13 +159,6 @@
 			<groupId>org.smartregister</groupId>
 			<artifactId>opensrp-server-common</artifactId>
 			<version>${opensrp.common.version}</version>
-			<!-- TODO remove after upgrading mockito in server common -->
-			<exclusions>
-				<exclusion>
-					<groupId>org.mockito</groupId>
-					<artifactId>mockito-all</artifactId>
-				</exclusion>
-			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.smartregister</groupId>


### PR DESCRIPTION
- [x] Upgrade server common to `2.0.0-alpha2-SNAPSHOT`

- [x] That version has testing dependencies updated and no need to ignore older Mockito libraries
