### PR TITLE
Move File Manager configuration to maven profiles 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -601,6 +601,42 @@
 			</properties>
 		</profile>
 		<profile>
+			<id>FileSystem</id>
+			<activation>
+				<property>
+					<name>opensrp.file.manager.type</name>
+					<value>FileSystem</value>
+				</property>
+			</activation>
+			<properties>
+				<opensrp.file.manager.profile>FileSystem</opensrp.file.manager.profile>
+			</properties>
+		</profile>
+		<profile>
+			<id>AWS_S3</id>
+			<activation>
+				<property>
+					<name>opensrp.file.manager.type</name>
+					<value>AWS_S3</value>
+				</property>
+			</activation>
+			<properties>
+				<opensrp.file.manager.profile>AWS_S3</opensrp.file.manager.profile>
+			</properties>
+		</profile>
+		<profile>
+			<id>AliCloud_OSS</id>
+			<activation>
+				<property>
+					<name>opensrp.file.manager.type</name>
+					<value>AliCloud_OSS</value>
+				</property>
+			</activation>
+			<properties>
+				<opensrp.file.manager.profile>AliCloud_OSS</opensrp.file.manager.profile>
+			</properties>
+		</profile>
+		<profile>
 			<id>release</id>
 			<build>
 				<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -88,12 +88,6 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.aliyun.oss</groupId>
-			<artifactId>aliyun-sdk-oss</artifactId>
-			<version>2.8.3</version>
-		</dependency>
-
-		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
 			<version>${jackson.version}</version>
@@ -106,12 +100,6 @@
 			<version>${jackson.version}</version>
 		</dependency>
 
-		<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
-		<dependency>
-			<groupId>com.amazonaws</groupId>
-			<artifactId>aws-java-sdk</artifactId>
-			<version>1.11.659</version>
-		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
@@ -603,6 +591,7 @@
 		<profile>
 			<id>FileSystem</id>
 			<activation>
+				<activeByDefault>true</activeByDefault>
 				<property>
 					<name>opensrp.file.manager.type</name>
 					<value>FileSystem</value>
@@ -611,6 +600,23 @@
 			<properties>
 				<opensrp.file.manager.profile>FileSystem</opensrp.file.manager.profile>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<excludes>
+								<exclude>**/OSSMultimediaFileManager.*</exclude>
+								<exclude>**/OSSClientBuilder.*</exclude>
+								<exclude>**/S3MultimediaFileManager.*</exclude>
+								<exclude>**/OSSMultimediaFileManagerTest.*</exclude>
+								<exclude>**/S3MultimediaFileManagerTest.*</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
 		</profile>
 		<profile>
 			<id>AWS_S3</id>
@@ -623,6 +629,29 @@
 			<properties>
 				<opensrp.file.manager.profile>AWS_S3</opensrp.file.manager.profile>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<excludes>
+								<exclude>**/OSSMultimediaFileManager.*</exclude>
+								<exclude>**/OSSClientBuilder.*</exclude>
+								<exclude>**/OSSMultimediaFileManagerTest.*</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+			<dependencies>
+				<!-- https://mvnrepository.com/artifact/com.amazonaws/aws-java-sdk -->
+				<dependency>
+					<groupId>com.amazonaws</groupId>
+					<artifactId>aws-java-sdk</artifactId>
+					<version>1.11.659</version>
+				</dependency>
+			</dependencies>
 		</profile>
 		<profile>
 			<id>AliCloud_OSS</id>
@@ -635,6 +664,27 @@
 			<properties>
 				<opensrp.file.manager.profile>AliCloud_OSS</opensrp.file.manager.profile>
 			</properties>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-compiler-plugin</artifactId>
+						<configuration>
+							<excludes>
+								<exclude>**/S3MultimediaFileManager.*</exclude>
+								<exclude>**/S3MultimediaFileManagerTest.*</exclude>
+							</excludes>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+			<dependencies>
+				<dependency>
+					<groupId>com.aliyun.oss</groupId>
+					<artifactId>aliyun-sdk-oss</artifactId>
+					<version>2.8.3</version>
+				</dependency>
+			</dependencies>
 		</profile>
 		<profile>
 			<id>release</id>

--- a/src/main/java/org/opensrp/service/MultimediaService.java
+++ b/src/main/java/org/opensrp/service/MultimediaService.java
@@ -5,7 +5,6 @@ import org.opensrp.dto.form.MultimediaDTO;
 import org.opensrp.repository.MultimediaRepository;
 import org.opensrp.service.multimedia.MultimediaFileManager;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
 
 import java.io.File;
@@ -81,7 +80,6 @@ public class MultimediaService {
 	}
 
 	@Autowired
-	@Qualifier("multimedia.file.manager")
 	public void setFileManager(MultimediaFileManager fileManager) {
 		this.fileManager = fileManager;
 	}

--- a/src/main/java/org/opensrp/service/multimedia/FileSystemMultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/FileSystemMultimediaFileManager.java
@@ -3,6 +3,7 @@ package org.opensrp.service.multimedia;
 import org.opensrp.repository.MultimediaRepository;
 import org.opensrp.service.ClientService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -11,8 +12,9 @@ import java.io.IOException;
 /**
  * Created by Vincent Karuri on 24/10/2019
  */
-
-@Component("FileSystemMultimediaFileManager")
+@Profile("FileSystem")
+//@Component("FileSystemMultimediaFileManager")
+@Component
 public class FileSystemMultimediaFileManager extends BaseMultimediaFileManager {
 
     @Autowired

--- a/src/main/java/org/opensrp/service/multimedia/FileSystemMultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/FileSystemMultimediaFileManager.java
@@ -13,8 +13,7 @@ import java.io.IOException;
  * Created by Vincent Karuri on 24/10/2019
  */
 @Profile("FileSystem")
-//@Component("FileSystemMultimediaFileManager")
-@Component
+@Component("FileSystemMultimediaFileManager")
 public class FileSystemMultimediaFileManager extends BaseMultimediaFileManager {
 
     @Autowired

--- a/src/main/java/org/opensrp/service/multimedia/OSSMultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/OSSMultimediaFileManager.java
@@ -9,6 +9,7 @@ import org.opensrp.service.ClientService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -22,7 +23,9 @@ import static org.opensrp.util.Utils.closeCloseable;
 /**
  * Created by Vincent Karuri on 20/05/2020
  */
-@Component("OSSMultimediaFileManager")
+@Profile("AliCloud_OSS")
+//@Component("OSSMultimediaFileManager")
+@Component
 public class OSSMultimediaFileManager extends ObjectStorageMultimediaFileManager {
 
 	private Logger logger = LoggerFactory.getLogger(OSSMultimediaFileManager.class.toString());

--- a/src/main/java/org/opensrp/service/multimedia/OSSMultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/OSSMultimediaFileManager.java
@@ -24,8 +24,7 @@ import static org.opensrp.util.Utils.closeCloseable;
  * Created by Vincent Karuri on 20/05/2020
  */
 @Profile("AliCloud_OSS")
-//@Component("OSSMultimediaFileManager")
-@Component
+@Component("OSSMultimediaFileManager")
 public class OSSMultimediaFileManager extends ObjectStorageMultimediaFileManager {
 
 	private Logger logger = LoggerFactory.getLogger(OSSMultimediaFileManager.class.toString());

--- a/src/main/java/org/opensrp/service/multimedia/S3MultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/S3MultimediaFileManager.java
@@ -26,8 +26,7 @@ import java.io.InputStream;
  * Created by Vincent Karuri on 24/10/2019
  */
 @Profile("AWS_S3")
-//@Component("S3MultimediaFileManager")
-@Component
+@Component("S3MultimediaFileManager")
 public class S3MultimediaFileManager extends ObjectStorageMultimediaFileManager {
 
 	private AmazonS3 s3Client;

--- a/src/main/java/org/opensrp/service/multimedia/S3MultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/S3MultimediaFileManager.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.opensrp.repository.MultimediaRepository;
 import org.opensrp.service.ClientService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import javax.annotation.PostConstruct;
@@ -24,7 +25,9 @@ import java.io.InputStream;
 /**
  * Created by Vincent Karuri on 24/10/2019
  */
-@Component("S3MultimediaFileManager")
+@Profile("AWS_S3")
+//@Component("S3MultimediaFileManager")
+@Component
 public class S3MultimediaFileManager extends ObjectStorageMultimediaFileManager {
 
 	private AmazonS3 s3Client;


### PR DESCRIPTION
Issue # 196
Move File Manager configuration to maven profiles
There should be 3 profiles FileSystem and AWS_S3, AliCloud_OSS
Load S3 dependencies only if S3 is used for storage of files
Load AliCloud_OSS dependencies only if AliCloud_OSS is used for storage of files