### PR TITLE
Add repository & service methods to fetch all client_form_metadata by is_draft_value

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.4.3-SNAPSHOT</version>
+	<version>2.4.4-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>http://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/repository/ClientFormRepository.java
+++ b/src/main/java/org/opensrp/repository/ClientFormRepository.java
@@ -5,6 +5,8 @@ import org.opensrp.domain.IdVersionTuple;
 import org.opensrp.domain.postgres.ClientForm;
 import org.opensrp.domain.postgres.ClientFormMetadata;
 import org.opensrp.service.ClientFormService;
+import org.springframework.lang.Nullable;
+
 import java.util.List;
 
 public interface ClientFormRepository extends BaseRepository<ClientForm> {
@@ -30,4 +32,6 @@ public interface ClientFormRepository extends BaseRepository<ClientForm> {
 
 	ClientFormService.CompleteClientForm create(@NonNull ClientFormService.CompleteClientForm completeClientForm);
 
+	@Nullable
+	List<ClientFormMetadata> getAllClientFormMetadata(boolean isDraft);
 }

--- a/src/main/java/org/opensrp/repository/ClientFormRepository.java
+++ b/src/main/java/org/opensrp/repository/ClientFormRepository.java
@@ -34,4 +34,7 @@ public interface ClientFormRepository extends BaseRepository<ClientForm> {
 
 	@Nullable
 	List<ClientFormMetadata> getAllClientFormMetadata(boolean isDraft);
+
+	@Nullable
+	List<ClientFormMetadata> getAllClientFormMetadata();
 }

--- a/src/main/java/org/opensrp/repository/postgres/ClientFormRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/ClientFormRepositoryImpl.java
@@ -96,6 +96,12 @@ public class ClientFormRepositoryImpl extends BaseRepositoryImpl<ClientForm> imp
 
 	@Nullable
 	@Override
+	public List<ClientFormMetadata> getAllClientFormMetadata(boolean isDraft) {
+		return clientFormMetadataMapper.getAllClientFormMetadata(isDraft);
+	}
+
+	@Nullable
+	@Override
 	public ClientForm get(String id) {
 		if (TextUtils.isEmpty(id)) {
 			return null;

--- a/src/main/java/org/opensrp/repository/postgres/ClientFormRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/ClientFormRepositoryImpl.java
@@ -97,7 +97,12 @@ public class ClientFormRepositoryImpl extends BaseRepositoryImpl<ClientForm> imp
 	@Nullable
 	@Override
 	public List<ClientFormMetadata> getAllClientFormMetadata(boolean isDraft) {
-		return clientFormMetadataMapper.getAllClientFormMetadata(isDraft);
+		return clientFormMetadataMapper.getClientFormMetadata(isDraft);
+	}
+
+	@Override
+	public List<ClientFormMetadata> getAllClientFormMetadata() {
+		return clientFormMetadataMapper.getAllClientFormMetadata();
 	}
 
 	@Nullable

--- a/src/main/java/org/opensrp/repository/postgres/mapper/custom/CustomClientFormMetadataMapper.java
+++ b/src/main/java/org/opensrp/repository/postgres/mapper/custom/CustomClientFormMetadataMapper.java
@@ -1,10 +1,10 @@
 package org.opensrp.repository.postgres.mapper.custom;
 
-import org.springframework.lang.NonNull;
 import org.apache.ibatis.annotations.Param;
 import org.opensrp.domain.IdVersionTuple;
 import org.opensrp.domain.postgres.ClientFormMetadata;
 import org.opensrp.repository.postgres.mapper.ClientFormMetadataMapper;
+import org.springframework.lang.NonNull;
 
 import java.util.List;
 
@@ -18,4 +18,6 @@ public interface CustomClientFormMetadataMapper extends ClientFormMetadataMapper
 	int insertClientFormMetadata(@NonNull ClientFormMetadata clientFormMetadata);
 
 	List<IdVersionTuple> getAvailableClientFormVersions(@Param("formIdentifier") @NonNull String formIdentifier, @Param("isJsonValidator") boolean isJsonValidator);
+
+	List<ClientFormMetadata> getAllClientFormMetadata(boolean isDraft);
 }

--- a/src/main/java/org/opensrp/repository/postgres/mapper/custom/CustomClientFormMetadataMapper.java
+++ b/src/main/java/org/opensrp/repository/postgres/mapper/custom/CustomClientFormMetadataMapper.java
@@ -19,5 +19,7 @@ public interface CustomClientFormMetadataMapper extends ClientFormMetadataMapper
 
 	List<IdVersionTuple> getAvailableClientFormVersions(@Param("formIdentifier") @NonNull String formIdentifier, @Param("isJsonValidator") boolean isJsonValidator);
 
-	List<ClientFormMetadata> getAllClientFormMetadata(boolean isDraft);
+	List<ClientFormMetadata> getClientFormMetadata(boolean isDraft);
+
+	List<ClientFormMetadata> getAllClientFormMetadata();
 }

--- a/src/main/java/org/opensrp/repository/postgres/mapper/custom/xml/CustomClientFormMetadataMapper.xml
+++ b/src/main/java/org/opensrp/repository/postgres/mapper/custom/xml/CustomClientFormMetadataMapper.xml
@@ -48,4 +48,8 @@
         SELECT id, version FROM core.client_form_metadata WHERE identifier = #{formIdentifier} AND
         is_json_validator = #{isJsonValidator, jdbcType=BIT}
     </select>
+
+    <select id="getAllClientFormMetadata" parameterType="boolean" resultMap="BaseClientFormMetadataResultMap">
+        SELECT * FROM core.client_form_metadata WHERE is_draft = #{isDraft, jdbcType=BIT}
+    </select>
 </mapper>

--- a/src/main/java/org/opensrp/repository/postgres/mapper/custom/xml/CustomClientFormMetadataMapper.xml
+++ b/src/main/java/org/opensrp/repository/postgres/mapper/custom/xml/CustomClientFormMetadataMapper.xml
@@ -49,7 +49,11 @@
         is_json_validator = #{isJsonValidator, jdbcType=BIT}
     </select>
 
-    <select id="getAllClientFormMetadata" parameterType="boolean" resultMap="BaseClientFormMetadataResultMap">
+    <select id="getClientFormMetadata" parameterType="boolean" resultMap="BaseClientFormMetadataResultMap">
         SELECT * FROM core.client_form_metadata WHERE is_draft = #{isDraft, jdbcType=BIT}
+    </select>
+
+    <select id="getAllClientFormMetadata" resultMap="BaseClientFormMetadataResultMap">
+        SELECT * FROM core.client_form_metadata
     </select>
 </mapper>

--- a/src/main/java/org/opensrp/service/ClientFormService.java
+++ b/src/main/java/org/opensrp/service/ClientFormService.java
@@ -10,6 +10,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -70,6 +72,12 @@ public class ClientFormService {
 		}
 
 		return clientFormRepository.create(clientForm, clientFormMetadata);
+	}
+
+	@NonNull
+	public List<ClientFormMetadata> getClientFormMetadata(boolean isDraft) {
+		List<ClientFormMetadata> clientFormMetadataList = clientFormRepository.getAllClientFormMetadata(isDraft);
+		return clientFormMetadataList == null ? new ArrayList<ClientFormMetadata>() : clientFormMetadataList;
 	}
 
 	public static class CompleteClientForm {

--- a/src/main/java/org/opensrp/service/ClientFormService.java
+++ b/src/main/java/org/opensrp/service/ClientFormService.java
@@ -80,6 +80,12 @@ public class ClientFormService {
 		return clientFormMetadataList == null ? new ArrayList<ClientFormMetadata>() : clientFormMetadataList;
 	}
 
+	@NonNull
+	public List<ClientFormMetadata> getAllClientFormMetadata() {
+		List<ClientFormMetadata> clientFormMetadataList = clientFormRepository.getAllClientFormMetadata();
+		return clientFormMetadataList == null ? new ArrayList<ClientFormMetadata>() : clientFormMetadataList;
+	}
+
 	public static class CompleteClientForm {
 
 		public ClientForm clientForm;

--- a/src/test/java/org/opensrp/service/ClientFormServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientFormServiceTest.java
@@ -2,7 +2,6 @@ package org.opensrp.service;
 
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.opensrp.domain.IdVersionTuple;
 import org.opensrp.domain.postgres.ClientForm;
 import org.opensrp.domain.postgres.ClientFormMetadata;
@@ -12,10 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class ClientFormServiceTest extends BaseRepositoryTest {
 
@@ -105,7 +101,7 @@ public class ClientFormServiceTest extends BaseRepositoryTest {
 	}
 
 	@Test
-	public void testGetAllClientFormMetadataShouldReturnOnlyDraftForms() {
+	public void testGetAllClientFormMetadataShouldReturnOnlyDraftFormsMetadata() {
 		int count = 10;
 
 		for (int i = 0; i < count; i++) {
@@ -130,9 +126,34 @@ public class ClientFormServiceTest extends BaseRepositoryTest {
 
 
 	@Test
-	public void testGetAllClientFormMetadataShouldReturnNonDraftForms() {
+	public void testGetAllClientFormMetadataShouldReturnNonDraftFormsMetadata() {
 		List<ClientFormMetadata> clientFormMetadataList = clientFormService.getClientFormMetadata(false);
 		assertEquals(5, clientFormMetadataList.size());
+	}
+
+
+	@Test
+	public void testGetAllClientFormMetadataShouldReturnAllFormMetadata() {
+		int count = 10;
+
+		for (int i = 0; i < count; i++) {
+			ClientForm clientForm = new ClientForm();
+			clientForm.setCreatedAt(new Date());
+			clientForm.setJson("{'from': 'child'}");
+
+			ClientFormMetadata clientFormMetadata = new ClientFormMetadata();
+			clientFormMetadata.setModule("child");
+			clientFormMetadata.setVersion("1.0." + i);
+			clientFormMetadata.setIdentifier("json.form/child/sample.json");
+			clientFormMetadata.setLabel("SAMPLE FORM");
+			clientFormMetadata.setIsDraft(true);
+			clientFormMetadata.setCreatedAt(new Date());
+
+			clientFormService.addClientForm(clientForm, clientFormMetadata);
+		}
+
+		List<ClientFormMetadata> clientFormMetadataList = clientFormService.getAllClientFormMetadata();
+		assertEquals(count + 5, clientFormMetadataList.size());
 	}
 
 	@Override

--- a/src/test/java/org/opensrp/service/ClientFormServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientFormServiceTest.java
@@ -2,6 +2,7 @@ package org.opensrp.service;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.opensrp.domain.IdVersionTuple;
 import org.opensrp.domain.postgres.ClientForm;
 import org.opensrp.domain.postgres.ClientFormMetadata;
@@ -101,6 +102,37 @@ public class ClientFormServiceTest extends BaseRepositoryTest {
 
 		assertEquals(6, (long) completeClientForm.clientForm.getId());
 		assertEquals(6, (long) completeClientForm.clientFormMetadata.getId());
+	}
+
+	@Test
+	public void testGetAllClientFormMetadataShouldReturnOnlyDraftForms() {
+		int count = 10;
+
+		for (int i = 0; i < count; i++) {
+			ClientForm clientForm = new ClientForm();
+			clientForm.setCreatedAt(new Date());
+			clientForm.setJson("{'from': 'child'}");
+
+			ClientFormMetadata clientFormMetadata = new ClientFormMetadata();
+			clientFormMetadata.setModule("child");
+			clientFormMetadata.setVersion("1.0." + i);
+			clientFormMetadata.setIdentifier("json.form/child/sample.json");
+			clientFormMetadata.setLabel("SAMPLE FORM");
+			clientFormMetadata.setIsDraft(true);
+			clientFormMetadata.setCreatedAt(new Date());
+
+			clientFormService.addClientForm(clientForm, clientFormMetadata);
+		}
+
+		List<ClientFormMetadata> clientFormMetadataList = clientFormService.getClientFormMetadata(true);
+		assertEquals(count, clientFormMetadataList.size());
+	}
+
+
+	@Test
+	public void testGetAllClientFormMetadataShouldReturnNonDraftForms() {
+		List<ClientFormMetadata> clientFormMetadataList = clientFormService.getClientFormMetadata(false);
+		assertEquals(5, clientFormMetadataList.size());
 	}
 
 	@Override

--- a/src/test/java/org/opensrp/service/ClientFormServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientFormServiceTest.java
@@ -11,7 +11,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 
 public class ClientFormServiceTest extends BaseRepositoryTest {
 


### PR DESCRIPTION
Add repository & service methods to fetch all client_form_metadata by is_draft_value

- Increment version to 2.4.4
- Add query to retrieve ClientFormMetadata by is_draft value in CustomClientFormMetadataMapper.xml