### PR TITLE
Remove limit restriction on getting child locations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.7.9-SNAPSHOT</version>
+	<version>2.7.10-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>http://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/repository/postgres/LocationRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/LocationRepositoryImpl.java
@@ -439,7 +439,6 @@ public class LocationRepositoryImpl extends BaseRepositoryImpl<PhysicalLocation>
 		}
 		
 		int limit = Math.abs(pageSize);
-		limit = limit < FETCH_SIZE_LIMIT ? limit : FETCH_SIZE_LIMIT;
 		List<Location> locations = locationMetadataMapper.selectWithChildren(locationMetadataExample, returnGeometry,
 		    identifiers, 0, limit);
 		return convert(locations);


### PR DESCRIPTION
Related to https://github.com/OpenSRP/opensrp-server-web/issues/541

- [x] Assignment as country levels are buggy when the location hierarchy has locations exceeding the hard limit of 5000