### PR TITLE
Date range type handler use UTC timezone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.7.16-SNAPSHOT</version>
+	<version>2.7.17-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>http://github.com/OpenSRP/opensrp-server-core</url>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
-			<version>4.13</version>
+			<version>4.13.1</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/opensrp/repository/postgres/handler/DateRangeTypeHandler.java
+++ b/src/main/java/org/opensrp/repository/postgres/handler/DateRangeTypeHandler.java
@@ -10,6 +10,7 @@ import java.sql.SQLException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.ibatis.type.JdbcType;
@@ -26,8 +27,13 @@ public class DateRangeTypeHandler extends BaseTypeHandler implements TypeHandler
 	
 	private static final Logger logger = LoggerFactory.getLogger(DateRangeTypeHandler.class);
 	
-	private SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+	private SimpleDateFormat dateFormat;
 	
+	public DateRangeTypeHandler() {
+		dateFormat = new SimpleDateFormat("yyyy-MM-dd");
+		dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+	}
+
 	@Override
 	public void setParameter(PreparedStatement ps, int i, DateRange parameter, JdbcType jdbcType) throws SQLException {
 		try {


### PR DESCRIPTION
- [x] Date range type handler use UTC timezone as used on OpenSRP postgres databases [configuration](https://github.com/ANXS/postgresql/blob/master/defaults/main.yml#L680)

Related to https://github.com/OpenSRP/opensrp-server-web/issues/573