### PR TITLE
392 : Set provider id to the provider id sent in a request payload in add inventory API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.8.15-SNAPSHOT</version>
+	<version>2.8.16-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>http://github.com/OpenSRP/opensrp-server-core</url>
@@ -24,7 +24,7 @@
 		<opensrp.common.version>2.0.3-SNAPSHOT</opensrp.common.version>
 		<opensrp.api.version>1.0.4-SNAPSHOT</opensrp.api.version>
 		<opensrp.interface.version>2.0.1-SNAPSHOT</opensrp.interface.version>
-		<opensrp.plan.evaluator.version>1.2.3-SNAPSHOT</opensrp.plan.evaluator.version>
+		<opensrp.plan.evaluator.version>1.2.4-SNAPSHOT</opensrp.plan.evaluator.version>
 		<jackson.version>2.10.2</jackson.version>
 		<powermock.version>2.0.5</powermock.version>
 		<lombok.version>1.18.12</lombok.version>

--- a/src/main/java/org/opensrp/service/StockService.java
+++ b/src/main/java/org/opensrp/service/StockService.java
@@ -328,7 +328,12 @@ public class StockService {
 		Map<String, String> customProperties = new HashMap<>();
 
 		stock.setIdentifier(String.valueOf(productCatalogue.getUniqueId()));
-		stock.setProviderid(username);
+		if(inventory.getProviderId() != null && !inventory.getProviderId().isBlank()) {
+			stock.setProviderid(inventory.getProviderId());
+		}
+		else {
+			stock.setProviderid(username);
+		}
 		stock.setValue(inventory.getQuantity());
 		stock.setTransactionType("Inventory");
 		stock.setLocationId(inventory.getServicePointId());

--- a/src/test/java/org/opensrp/service/StockServiceTest.java
+++ b/src/test/java/org/opensrp/service/StockServiceTest.java
@@ -164,6 +164,7 @@ public class StockServiceTest extends BaseRepositoryTest {
 	@Test
 	public void testAddInventory() {
 		Inventory inventory = createInventory();
+		inventory.setProviderId("test provider");
 		List<String> donorsList = createDonorList();
 		List<String> sectionsList = createSectionsList();
 		when(productCatalogueService.getProductCatalogueByName(anyString())).thenReturn(createProductCatalogue());

--- a/src/test/java/org/opensrp/service/StockServiceTest.java
+++ b/src/test/java/org/opensrp/service/StockServiceTest.java
@@ -164,6 +164,25 @@ public class StockServiceTest extends BaseRepositoryTest {
 	@Test
 	public void testAddInventory() {
 		Inventory inventory = createInventory();
+		List<String> donorsList = createDonorList();
+		List<String> sectionsList = createSectionsList();
+		when(productCatalogueService.getProductCatalogueByName(anyString())).thenReturn(createProductCatalogue());
+		when(inventoryDataValidator.getValidDonors()).thenReturn(donorsList);
+		when(inventoryDataValidator.getValidUnicefSections()).thenReturn(sectionsList);
+		when(physicalLocationService.getStructure(anyString(), anyBoolean())).thenReturn(createLocation());
+		stockService.addInventory(inventory, "John");
+		StockSearchBean stockSearchBean =  new StockSearchBean();
+		List<String> locations = new ArrayList<>();
+		locations.add("loc-1");
+		stockSearchBean.setLocations(locations);
+		stockSearchBean.setPageNumber(1);
+		List<Stock> stockList = stockService.getStocksByServicePointId(stockSearchBean);
+		Assert.assertEquals(1, stockList.size());
+	}
+
+	@Test
+	public void testAddInventoryWithProviderId() {
+		Inventory inventory = createInventory();
 		inventory.setProviderId("test provider");
 		List<String> donorsList = createDonorList();
 		List<String> sectionsList = createSectionsList();
@@ -179,6 +198,7 @@ public class StockServiceTest extends BaseRepositoryTest {
 		stockSearchBean.setPageNumber(1);
 		List<Stock> stockList = stockService.getStocksByServicePointId(stockSearchBean);
 		Assert.assertEquals(1, stockList.size());
+		Assert.assertEquals("test provider", stockList.get(0).getProviderid());
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/OpenSRP/opensrp-server-core/issues/392

If provider Id is not sent in a request payload, then userName will be set as a provider Id.
@githengi 