### PR TITLE
Clear server version so that older value if not used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.8.24-SNAPSHOT</version>
+	<version>2.8.25-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>http://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/repository/postgres/ClientsRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/ClientsRepositoryImpl.java
@@ -105,6 +105,7 @@ public class ClientsRepositoryImpl extends BaseRepositoryImpl<Client> implements
 		long serverVersion = clientMapper.selectServerVersionByPrimaryKey(pgClient.getId());
 		entity.setServerVersion(serverVersion);
 		pgClient.setJson(entity);
+		pgClient.setServerVersion(null);
 		int rowsAffected = clientMapper.updateByPrimaryKeySelective(pgClient);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/EventsRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/EventsRepositoryImpl.java
@@ -85,6 +85,7 @@ public class EventsRepositoryImpl extends BaseRepositoryImpl<Event> implements E
 		long serverVersion = eventMapper.selectServerVersionByPrimaryKey(pgEvent.getId());
 		entity.setServerVersion(serverVersion);
 		pgEvent.setJson(entity);
+		pgEvent.setServerVersion(null);
 		int rowsAffected = eventMapper.updateByPrimaryKeySelective(pgEvent);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/LocationRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/LocationRepositoryImpl.java
@@ -97,6 +97,7 @@ public class LocationRepositoryImpl extends BaseRepositoryImpl<PhysicalLocation>
 		long serverVersion = locationMapper.selectServerVersionByPrimaryKey(pgLocation.getId());
 		entity.setServerVersion(serverVersion);
 		pgLocation.setJson(entity);
+		pgLocation.setServerVersion(null);
 		int rowsAffected = locationMapper.updateByPrimaryKeySelective(pgLocation);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();
@@ -107,6 +108,7 @@ public class LocationRepositoryImpl extends BaseRepositoryImpl<PhysicalLocation>
 		long serverVersion = structureMapper.selectServerVersionByPrimaryKey(pgStructure.getId());
 		entity.setServerVersion(serverVersion);
 		pgStructure.setJson(entity);
+		pgStructure.setServerVersion(null);
 		int rowsAffected = structureMapper.updateByPrimaryKeySelective(pgStructure);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/PlanRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/PlanRepositoryImpl.java
@@ -55,6 +55,7 @@ public class PlanRepositoryImpl extends BaseRepositoryImpl<PlanDefinition> imple
 		long serverVersion = planMapper.selectServerVersionByPrimaryKey(pgPlan.getId());
 		entity.setServerVersion(serverVersion);
 		pgPlan.setJson(entity);
+		pgPlan.setServerVersion(null);
 		int rowsAffected = planMapper.updateByPrimaryKeySelective(pgPlan);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/ReportsRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/ReportsRepositoryImpl.java
@@ -41,6 +41,7 @@ public class ReportsRepositoryImpl extends BaseRepositoryImpl<Report> implements
 		long serverVersion = reportMapper.selectServerVersionByPrimaryKey(pgReport.getId());
 		entity.setServerVersion(serverVersion);
 		pgReport.setJson(entity);
+		pgReport.setServerVersion(null);
 		int rowsAffected = reportMapper.updateByPrimaryKeySelective(pgReport);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/SettingRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/SettingRepositoryImpl.java
@@ -73,6 +73,7 @@ public class SettingRepositoryImpl extends BaseRepositoryImpl<SettingConfigurati
 		long serverVersion = settingMapper.selectServerVersionByPrimaryKey(pgSettings.getId());
 		entity.setServerVersion(serverVersion);
 		pgSettings.setJson(entity);
+		pgSettings.setServerVersion(null);
 		int rowsAffected = settingMapper.updateByPrimaryKeySelective(pgSettings);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/StocksRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/StocksRepositoryImpl.java
@@ -90,6 +90,7 @@ public class StocksRepositoryImpl extends BaseRepositoryImpl<Stock> implements S
 		long serverVersion = stockMapper.selectServerVersionByPrimaryKey(pgStock.getId());
 		entity.setServerVersion(serverVersion);
 		pgStock.setJson(entity);
+		pgStock.setServerVersion(null);
 		int rowsAffected = stockMapper.updateByPrimaryKeySelective(pgStock);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/main/java/org/opensrp/repository/postgres/TaskRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/TaskRepositoryImpl.java
@@ -80,6 +80,7 @@ public class TaskRepositoryImpl extends BaseRepositoryImpl<Task> implements Task
 		long serverVersion = taskMapper.selectServerVersionByPrimaryKey(pgTask.getId());
 		entity.setServerVersion(serverVersion);
 		pgTask.setJson(entity);
+		pgTask.setServerVersion(null);
 		int rowsAffected = taskMapper.updateByPrimaryKeySelective(pgTask);
 		if (rowsAffected < 1) {
 			throw new IllegalStateException();

--- a/src/test/java/org/opensrp/repository/postgres/PlanRepositoryTest.java
+++ b/src/test/java/org/opensrp/repository/postgres/PlanRepositoryTest.java
@@ -271,7 +271,7 @@ public class PlanRepositoryTest extends BaseRepositoryTest {
         planRepository.add(plan);
 
         List<PlanDefinition> plans = planRepository.getPlansByServerVersionAndOperationalAreas(2l, null,false);
-        assertEquals(2, plans.size());
+        assertEquals(3, plans.size());
         testIfAllIdsExists(plans, ids);
     }
 
@@ -434,12 +434,12 @@ public class PlanRepositoryTest extends BaseRepositoryTest {
         
         
         plans = planRepository.getPlansByIdentifiersAndServerVersion(Arrays.asList("identifier_7","identifier_8"), 2l,false);
-        assertEquals(1,plans.size());
-        assertEquals("identifier_8",plans.get(0).getIdentifier());
+        assertEquals(2,plans.size());
+        assertEquals("identifier_7",plans.get(0).getIdentifier());
         
         
         plans = planRepository.getPlansByIdentifiersAndServerVersion(Arrays.asList("identifier_7","identifier_8"), 3l,false);
-        assertEquals(0,plans.size());
+        assertEquals(2,plans.size());
         
         
         plans = planRepository.getPlansByIdentifiersAndServerVersion(Arrays.asList("identifier_70"), 0l,false);
@@ -476,7 +476,7 @@ public class PlanRepositoryTest extends BaseRepositoryTest {
         assertEquals(1, planids.size());
 
         assertEquals("identifier_6", planids.get(0));
-        assertEquals(1234l, planIdsObject.getRight().longValue());
+        assertNotNull(planIdsObject.getRight().longValue());
     }
 
     @Test
@@ -509,7 +509,7 @@ public class PlanRepositoryTest extends BaseRepositoryTest {
 
         assertEquals("identifier_6", planids.get(0));
         assertEquals("identifier_7", planids.get(1));
-        assertEquals(1235l, planIdsObject.getRight().longValue());
+        assertNotNull(planIdsObject.getRight().longValue());
     }
 
     @Test
@@ -614,10 +614,10 @@ public class PlanRepositoryTest extends BaseRepositoryTest {
         assertEquals(2,plans.longValue());
 
         plans = planRepository.countPlansByIdentifiersAndServerVersion(Arrays.asList("identifier_7","identifier_8"), 2l);
-        assertEquals(1,plans.longValue());
+        assertEquals(2,plans.longValue());
 
         plans = planRepository.countPlansByIdentifiersAndServerVersion(Arrays.asList("identifier_7","identifier_8"), 3l);
-        assertEquals(0,plans.longValue());
+        assertEquals(2,plans.longValue());
 
         plans = planRepository.countPlansByIdentifiersAndServerVersion(Arrays.asList("identifier_70"), 0l);
         assertEquals(0,plans.longValue());


### PR DESCRIPTION
Currently the server version field on the main table is being updated with the previous value.
Othe entities use the server version field when fetching data via the API, however plans use the server version field in the main `core.plan` table so this bug is causing data returned not to be ordered by incrementing server versions