### PR TITLE
Allow Move to My Catchment Events Sync Without Location Filter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.8-SNAPSHOT</version>
+	<version>3.0.9-ALPHA1-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.9-ALPHA1-SNAPSHOT</version>
+	<version>3.0.9-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -54,6 +54,10 @@ public class ClientService {
 		return allClients.findAllByIdentifier(identifierType, identifier);
 	}
 
+	public List<Client> findAllByIdentifierUnfiltered(String identifierType, String identifier) {
+		return allClients.findAllByIdentifier(identifierType, identifier);
+	}
+
 	@PreAuthorize("hasRole('CLIENT_VIEW')")
 	@PostFilter("hasPermission(filterObject, 'CLIENT_VIEW')")
 	public List<Client> findByRelationshipIdAndDateCreated(String relationalId, String dateFrom, String dateTo) {
@@ -75,6 +79,10 @@ public class ClientService {
 	@PreAuthorize("hasRole('CLIENT_VIEW')")
 	@PostFilter("hasPermission(filterObject, 'CLIENT_VIEW')")
 	public List<Client> findAllByAttribute(String attributeType, String attribute) {
+		return allClients.findAllByAttribute(attributeType, attribute);
+	}
+
+	public List<Client> findAllByAttributeUnfiltered(String attributeType, String attribute) {
 		return allClients.findAllByAttribute(attributeType, attribute);
 	}
 

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -271,7 +271,7 @@ public class ClientService {
 	@PreAuthorize("((hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE'))) and"
 			+ " (hasPermission(#client,'Client','CLIENT_CREATE') or hasPermission(#client,'Client','CLIENT_UPDATE')))"
 			+ " or (hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE')) or"
-			+ " hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or (hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE')))")
+			+ " hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE'))")
 	public Client addorUpdate(Client client) {
 		if (client.getBaseEntityId() == null) {
 			throw new RuntimeException("No baseEntityId");

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -270,8 +270,8 @@ public class ClientService {
 
 	@PreAuthorize("((hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE'))) and"
 			+ " (hasPermission(#client,'Client','CLIENT_CREATE') or hasPermission(#client,'Client','CLIENT_UPDATE')))"
-			+ " or (hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE')) or"
-			+ " hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE'))")
+			+ " or ((hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE')) or"
+			+ " hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE')))")
 	public Client addorUpdate(Client client) {
 		if (client.getBaseEntityId() == null) {
 			throw new RuntimeException("No baseEntityId");

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -268,24 +268,15 @@ public class ClientService {
 		return allClients.findByRelationShip(id);
 	}
 
-	@PreAuthorize("(hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE'))) and"
-			+ " (hasPermission(#client,'Client','CLIENT_CREATE') or hasPermission(#client,'Client','CLIENT_UPDATE'))")
+	@PreAuthorize("((hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE'))) and"
+			+ " (hasPermission(#client,'Client','CLIENT_CREATE') or hasPermission(#client,'Client','CLIENT_UPDATE')))"
+			+ " or (hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE')) or"
+			+ " hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or (hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE')))")
 	public Client addorUpdate(Client client) {
-		return addOrUpdateClient(client);
-	}
-
-	@PreAuthorize("hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or (hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE'))")
-	public Client addOrUpdateOutOfCatchment(Client client) {
-		return addOrUpdateClient(client);
-	}
-
-	private Client addOrUpdateClient(Client client) {
 		if (client.getBaseEntityId() == null) {
 			throw new RuntimeException("No baseEntityId");
 		}
-
 		Client c = findClient(client);
-
 		if (c != null) {
 			client.setRevision(c.getRevision());
 			client.setId(c.getId());

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -271,17 +271,27 @@ public class ClientService {
 	@PreAuthorize("(hasRole('CLIENT_CREATE') or (hasRole('CLIENT_UPDATE'))) and"
 			+ " (hasPermission(#client,'Client','CLIENT_CREATE') or hasPermission(#client,'Client','CLIENT_UPDATE'))")
 	public Client addorUpdate(Client client) {
+		return addOrUpdateClient(client);
+	}
+
+	@PreAuthorize("hasRole('CLIENT_OUT_OF_CATCHMENT_CREATE') or (hasRole('CLIENT_OUT_OF_CATCHMENT_UPDATE'))")
+	public Client addOrUpdateOutOfCatchment(Client client) {
+		return addOrUpdateClient(client);
+	}
+
+	private Client addOrUpdateClient(Client client) {
 		if (client.getBaseEntityId() == null) {
 			throw new RuntimeException("No baseEntityId");
 		}
+
 		Client c = findClient(client);
+
 		if (c != null) {
 			client.setRevision(c.getRevision());
 			client.setId(c.getId());
 			client.setDateEdited(DateTime.now());
 			client.addIdentifier("OPENMRS_UUID", c.getIdentifier("OPENMRS_UUID"));
 			allClients.update(client);
-			
 		} else {
 			client.setDateCreated(DateTime.now());
 			allClients.add(client);

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -54,7 +54,7 @@ public class ClientService {
 		return allClients.findAllByIdentifier(identifierType, identifier);
 	}
 
-	public List<Client> findAllByIdentifierUnfiltered(String identifierType, String identifier) {
+	public List<Client> findAllByIdentifierOutOfCatchment(String identifierType, String identifier) {
 		return allClients.findAllByIdentifier(identifierType, identifier);
 	}
 
@@ -82,7 +82,7 @@ public class ClientService {
 		return allClients.findAllByAttribute(attributeType, attribute);
 	}
 
-	public List<Client> findAllByAttributeUnfiltered(String attributeType, String attribute) {
+	public List<Client> findAllByAttributeOutOfCatchment(String attributeType, String attribute) {
 		return allClients.findAllByAttribute(attributeType, attribute);
 	}
 
@@ -265,8 +265,8 @@ public class ClientService {
 		return allClients.findByFieldValue(field, ids);
 	}
 
-	@PreAuthorize("hasRole('CLIENT_OUT_OF_CATCHMENT_VIEW')")
-	public List<Client> findOutOfCatchmentByFieldValue(String field, List<String> ids) {
+	@PreAuthorize("hasRole('CLIENT_VIEW') or hasRole('CLIENT_OUT_OF_CATCHMENT_VIEW')")
+	public List<Client> findByFieldValueOutOfCatchment(String field, List<String> ids) {
 		return allClients.findByFieldValue(field, ids);
 	}
 

--- a/src/main/java/org/opensrp/service/ClientService.java
+++ b/src/main/java/org/opensrp/service/ClientService.java
@@ -257,6 +257,11 @@ public class ClientService {
 		return allClients.findByFieldValue(field, ids);
 	}
 
+	@PreAuthorize("hasRole('CLIENT_OUT_OF_CATCHMENT_VIEW')")
+	public List<Client> findOutOfCatchmentByFieldValue(String field, List<String> ids) {
+		return allClients.findByFieldValue(field, ids);
+	}
+
 	@PreAuthorize("hasRole('CLIENT_VIEW')")
 	@PostFilter("hasPermission(filterObject, 'CLIENT_VIEW')")
 	public List<Client> findByFieldValue(String id) {

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -224,7 +224,7 @@ public class EventService {
 		return event;
 	}
 
-	public synchronized Event addEventUnfiltered(Event event, String username) {
+	public synchronized Event addEventOutOfCatchment(Event event, String username) {
 		Event e = find(event);
 		if (e != null) {
 			throw new IllegalArgumentException(
@@ -267,19 +267,15 @@ public class EventService {
 			}
 
 			List<org.smartregister.domain.Client> clients = identifier.startsWith(CARD_ID_PREFIX)
-							? clientService.findAllByAttributeUnfiltered(NFC_CARD_IDENTIFIER, identifier.substring(CARD_ID_PREFIX.length()))
-							: getClientByIdentifierUnfiltered(identifier);
-
-			logger.debug("Out of Area clients: " + clients.size());
+							? clientService.findAllByAttributeOutOfCatchment(NFC_CARD_IDENTIFIER, identifier.substring(CARD_ID_PREFIX.length()))
+							: getClientByIdentifierOutOfCatchment(identifier);
 
 			if (clients == null || clients.isEmpty()) {
 				return event;
 			}
 
 			for (org.smartregister.domain.Client client : clients) {
-				logger.debug("Out of Area client: " + (new Gson().toJson(client)));
-
-				List<Event> existingEvents = findByBaseEntityAndTypeUnfiltered(client.getBaseEntityId(), BIRTH_REGISTRATION_EVENT);
+				List<Event> existingEvents = findByBaseEntityAndTypeOutOfCatchment(client.getBaseEntityId(), BIRTH_REGISTRATION_EVENT);
 
 				if (existingEvents == null || existingEvents.isEmpty()) {
 					return event;
@@ -313,7 +309,7 @@ public class EventService {
 
 					if (actualEventType != null) {
 						Event newEvent = getNewOutOfAreaServiceEvent(event, birthRegEvent, actualEventType);
-						addEventUnfiltered(newEvent, birthRegEvent.getProviderId());
+						addEventOutOfCatchment(newEvent, birthRegEvent.getProviderId());
 					}
 				} else if (eventTypeLowercase.contains(RECURRING_SERVICE.toLowerCase()) ||
 						eventTypeLowercase.contains(RECURRING_SERVICE_UNDERSCORED)) {
@@ -503,10 +499,10 @@ public class EventService {
 		return clients;
 	}
 
-	private List<org.smartregister.domain.Client> getClientByIdentifierUnfiltered(String identifier) {
-		List<org.smartregister.domain.Client> clients = clientService.findAllByIdentifierUnfiltered(Client.ZEIR_ID, identifier);
+	private List<org.smartregister.domain.Client> getClientByIdentifierOutOfCatchment(String identifier) {
+		List<org.smartregister.domain.Client> clients = clientService.findAllByIdentifierOutOfCatchment(Client.ZEIR_ID, identifier);
 		if (clients != null && clients.isEmpty()) {
-			clients = clientService.findAllByIdentifierUnfiltered(Client.ZEIR_ID.toUpperCase(), identifier);
+			clients = clientService.findAllByIdentifierOutOfCatchment(Client.ZEIR_ID.toUpperCase(), identifier);
 		}
 		return clients;
 	}
@@ -587,7 +583,7 @@ public class EventService {
 		return allEvents.findByServerVersion(serverVersion);
 	}
 
-	public List<Event> findByServerVersionUnfiltered(long serverVersion) {
+	public List<Event> findByServerVersionOutOfCatchment(long serverVersion) {
 		return allEvents.findByServerVersion(serverVersion);
 	}
 
@@ -615,7 +611,7 @@ public class EventService {
 		return allEvents.findEvents(eventSearchBean, sortBy, sortOrder, limit);
 	}
 
-	@PreAuthorize("hasRole('EVENT_OUT_OF_CATCHMENT_VIEW')")
+	@PreAuthorize("hasRole('EVENT_VIEW') or hasRole('EVENT_OUT_OF_CATCHMENT_VIEW')")
 	public List<Event> findOutOfCatchmentEvents(EventSearchBean eventSearchBean, String sortBy, String sortOrder, int limit) {
 		return allEvents.findEvents(eventSearchBean, sortBy, sortOrder, limit);
 	}
@@ -637,12 +633,10 @@ public class EventService {
 	@PostFilter("hasPermission(filterObject, 'EVENT_VIEW')")
 	public List<Event> findByBaseEntityAndType(String baseEntityId, String eventType) {
 		return allEvents.findByBaseEntityAndType(baseEntityId, eventType);
-
 	}
 
-	public List<Event> findByBaseEntityAndTypeUnfiltered(String baseEntityId, String eventType) {
+	public List<Event> findByBaseEntityAndTypeOutOfCatchment(String baseEntityId, String eventType) {
 		return allEvents.findByBaseEntityAndType(baseEntityId, eventType);
-
 	}
 
 	@PreAuthorize("hasRole('EVENT_VIEW')")

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -254,8 +254,13 @@ public class EventService {
 	 */
 	public synchronized Event processOutOfArea(Event event) {
 		try {
-			String identifier = StringUtils.isBlank(event.getIdentifier(Client.ZEIR_ID)) ?
-					event.getIdentifier(OPENSRP_ID) : event.getIdentifier(Client.ZEIR_ID);
+			String programClientId = event.getDetails().getOrDefault("program_client_id", "");
+
+			String identifier = StringUtils.isBlank(event.getIdentifier(Client.ZEIR_ID))
+					? (StringUtils.isBlank(event.getIdentifier(OPENSRP_ID)) ? programClientId : event.getIdentifier(OPENSRP_ID))
+					: event.getIdentifier(Client.ZEIR_ID);
+
+			logger.info("Processing out of area event: baseEntityId=" + event.getBaseEntityId() + "; identifier=" + identifier);
 
 			if (StringUtils.isNotBlank(event.getBaseEntityId()) || StringUtils.isBlank(identifier)) {
 				return event;

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -471,7 +471,8 @@ public class EventService {
 		return clients;
 	}
 
-	@PreAuthorize("hasPermission(#event,'Event', 'EVENT_CREATE') and hasPermission(#event,'Event', 'EVENT_UPDATE')")
+	@PreAuthorize("(hasPermission(#event,'Event', 'EVENT_CREATE') and hasPermission(#event,'Event', 'EVENT_UPDATE'))"
+			+ " or (hasRole('EVENT_OUT_OF_CATCHMENT_CREATE') or hasRole('EVENT_OUT_OF_CATCHMENT_UPDATE'))")
 	public synchronized Event addorUpdateEvent(Event event, String username) {
 		Event existingEvent = findByIdOrFormSubmissionId(event.getId(), event.getFormSubmissionId());
 		if (existingEvent != null) {

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -570,7 +570,7 @@ public class EventService {
 		return allEvents.findEvents(eventSearchBean, sortBy, sortOrder, limit);
 	}
 
-	@PreAuthorize("hasRole('EVENT_VIEW')")
+	@PreAuthorize("hasRole('EVENT_OUT_OF_CATCHMENT_VIEW')")
 	public List<Event> findOutOfCatchmentEvents(EventSearchBean eventSearchBean, String sortBy, String sortOrder, int limit) {
 		return allEvents.findEvents(eventSearchBean, sortBy, sortOrder, limit);
 	}

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -1,7 +1,6 @@
 package org.opensrp.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.google.gson.Gson;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.LogManager;

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -441,10 +441,15 @@ public class EventService {
 	}
 
 	private Event getNewOutOfAreaServiceEvent(Event event, Event birthRegEvent, String eventType) {
+		String eventId = event.getBaseEntityId();
+		if (StringUtils.isEmpty(eventId)) {
+			eventId = birthRegEvent.getBaseEntityId();
+		}
+
 		event.setBaseEntityId(birthRegEvent.getBaseEntityId());
 		removeIdentifier(event); //Remove identifier from the old event first because entity id is found
 		Event newEvent = new Event();
-		newEvent.withBaseEntityId(event.getBaseEntityId())
+		newEvent.withBaseEntityId(eventId)
 				.withEventType(eventType)
 				.withEventDate(event.getEventDate())
 				.withEntityType(event.getEntityType())
@@ -654,7 +659,7 @@ public class EventService {
 	 */
 	public Long countEvents(EventSearchBean eventSearchBean) {
 		return allEvents.countEvents(eventSearchBean);
-	};
+	}
 
 	/**
 	 * This method is similar to {@link #findEventsByConceptAndValue(String, String)}. This method however does not enforce ACL

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -571,6 +571,11 @@ public class EventService {
 	}
 
 	@PreAuthorize("hasRole('EVENT_VIEW')")
+	public List<Event> findOutOfCatchmentEvents(EventSearchBean eventSearchBean, String sortBy, String sortOrder, int limit) {
+		return allEvents.findEvents(eventSearchBean, sortBy, sortOrder, limit);
+	}
+
+	@PreAuthorize("hasRole('EVENT_VIEW')")
 	@PostFilter("hasPermission(filterObject, 'EVENT_VIEW')")
 	public List<Event> findEvents(EventSearchBean eventSearchBean) {
 		return allEvents.findEvents(eventSearchBean);

--- a/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
+++ b/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
@@ -8,7 +8,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
-import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;

--- a/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
+++ b/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
@@ -58,7 +58,7 @@ public class EventsListener {
 			logger.info("Fetching Events");
 			long version = getVersion();
 			
-			List<Event> events = eventService.findByServerVersion(version);
+			List<Event> events = eventService.findByServerVersionUnfiltered(version);
 			
 			if (events.isEmpty()) {
 				logger.info("No new events found. Export token: " + version);

--- a/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
+++ b/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
@@ -71,8 +71,6 @@ public class EventsListener {
 			sort(events, serverVersionComparator());
 			
 			for (Event event : events) {
-				logger.info("Processing event: " + event.getFormSubmissionId() + " - " + (new Gson().toJson(event)));
-
 				try {
 					event = eventService.processOutOfArea(event);
 					eventsRouter.route(event);

--- a/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
+++ b/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
@@ -8,6 +8,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 
+import com.google.gson.Gson;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.joda.time.DateTime;
@@ -70,6 +71,8 @@ public class EventsListener {
 			sort(events, serverVersionComparator());
 			
 			for (Event event : events) {
+				logger.info("Processing event: " + event.getFormSubmissionId() + " - " + (new Gson().toJson(event)));
+
 				try {
 					event = eventService.processOutOfArea(event);
 					eventsRouter.route(event);

--- a/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
+++ b/src/main/java/org/opensrp/service/formSubmission/EventsListener.java
@@ -59,7 +59,7 @@ public class EventsListener {
 			logger.info("Fetching Events");
 			long version = getVersion();
 			
-			List<Event> events = eventService.findByServerVersionUnfiltered(version);
+			List<Event> events = eventService.findByServerVersionOutOfCatchment(version);
 			
 			if (events.isEmpty()) {
 				logger.info("No new events found. Export token: " + version);

--- a/src/test/java/org/opensrp/service/ClientServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientServiceTest.java
@@ -1,5 +1,6 @@
 package org.opensrp.service;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -7,6 +8,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opensrp.common.AllConstants.Client.OPENMRS_UUID_IDENTIFIER_TYPE;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -243,5 +245,20 @@ public class ClientServiceTest extends BaseRepositoryTest {
 		List<Client> clients = clientService.findAllByAttribute("Father_NRC_Number","721345/67/8");
 		assertNotNull(clients);
 		assertEquals("86c039a2-0b68-4166-849e-f49897e3a510", clients.get(0).getBaseEntityId());
+	}
+
+	@Test
+	public void testFindAllByAttributeOutOfCatchment() {
+		List<Client> clients = clientService.findAllByAttributeOutOfCatchment("Father_NRC_Number","721345/67/8");
+		assertNotNull(clients);
+		assertEquals("86c039a2-0b68-4166-849e-f49897e3a510", clients.get(0).getBaseEntityId());
+	}
+
+	@Test
+	public void testFindAllByAttributes() {
+		List<String> attributes = asList("Dar Naim", "Happy Kids Clinic");
+		List<Client> clients = clientService.findAllByAttributes("Home_Facility",attributes);
+		assertNotNull(clients);
+		assertEquals(9, clients.size());
 	}
 }

--- a/src/test/java/org/opensrp/service/ClientServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientServiceTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.opensrp.common.AllConstants.Client.OPENMRS_UUID_IDENTIFIER_TYPE;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -17,8 +16,6 @@ import org.joda.time.DateTime;
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
-import org.opensrp.common.AllConstants;
-import org.opensrp.domain.postgres.ClientFormMetadata;
 import org.smartregister.domain.Address;
 import org.smartregister.domain.Client;
 import org.opensrp.repository.ClientsRepository;

--- a/src/test/java/org/opensrp/service/ClientServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientServiceTest.java
@@ -254,8 +254,15 @@ public class ClientServiceTest extends BaseRepositoryTest {
 	@Test
 	public void testFindAllByAttributes() {
 		List<String> attributes = asList("Dar Naim", "Happy Kids Clinic");
-		List<Client> clients = clientService.findAllByAttributes("Home_Facility",attributes);
+		List<Client> clients = clientService.findAllByAttributes("Home_Facility", attributes);
 		assertNotNull(clients);
 		assertEquals(9, clients.size());
+	}
+
+	@Test
+	public void testFindAllByMatchingName() {
+		List<Client> clients = clientService.findAllByMatchingName("Child");
+		assertNotNull(clients);
+		assertEquals(6, clients.size());
 	}
 }

--- a/src/test/java/org/opensrp/service/ClientServiceTest.java
+++ b/src/test/java/org/opensrp/service/ClientServiceTest.java
@@ -15,6 +15,8 @@ import org.joda.time.DateTime;
 import org.json.JSONException;
 import org.junit.Before;
 import org.junit.Test;
+import org.opensrp.common.AllConstants;
+import org.opensrp.domain.postgres.ClientFormMetadata;
 import org.smartregister.domain.Address;
 import org.smartregister.domain.Client;
 import org.opensrp.repository.ClientsRepository;
@@ -24,89 +26,89 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 
 public class ClientServiceTest extends BaseRepositoryTest {
-	
+
 	private ClientService clientService;
-	
+
 	@Autowired
 	@Qualifier("clientsRepositoryPostgres")
 	private ClientsRepository clientsRepository;
-	
+
 	@Before
 	public void setUpPostgresRepository() {
 		clientService = new ClientService(clientsRepository);
 	}
-	
+
 	@Override
 	protected Set<String> getDatabaseScripts() {
 		Set<String> scripts = new HashSet<String>();
 		scripts.add("client.sql");
 		return scripts;
 	}
-	
+
 	@Test
 	public void testAddClient() {
 		Client client = new Client("f67823b0-378e-4a35-93fc-bb00def74e2f").withBirthdate(new DateTime("2017-03-31"), true)
-		        .withGender("Male").withFirstName("xobili").withLastName("mbangwa");
+				.withGender("Male").withFirstName("xobili").withLastName("mbangwa");
 		client.withIdentifier("ZEIR_ID", "233864-8").withAttribute("Home_Facility", "Linda");
 		clientService.addClient(client);
 		assertEquals(24, clientService.findAllClients().size());
-		
+
 		Client savedClient = clientService.find("f67823b0-378e-4a35-93fc-bb00def74e2f");
 		assertNotNull(savedClient.getId());
 		assertEquals(new DateTime("2017-03-31"), client.getBirthdate());
 		assertEquals("xobili", client.getFirstName());
 		assertEquals("mbangwa", client.getLastName());
 		assertEquals("233864-8", client.getIdentifier("ZEIR_ID"));
-		
+
 		//test adding existing client is updated
 		DateTime timeBeforeUpdate = new DateTime();
 		savedClient.withMiddleName("Rustus");
 		clientService.addClient(savedClient);
-		
+
 		Client updatedClient = clientService.find(savedClient.getBaseEntityId());
 		assertEquals("Rustus", updatedClient.getMiddleName());
 		assertEquals(ClientsRepositoryImpl.REVISION_PREFIX + 2, updatedClient.getRevision());
 		assertTrue(timeBeforeUpdate.isBefore(updatedClient.getDateEdited()));
-		
+
 	}
-	
+
 	@Test
 	public void testFindClient() {
 		Client client = new Client("33d9a17f-d729-4276-9891-b43e8b60fd12");
 		assertEquals("05934ae338431f28bf6793b24159c647", clientService.findClient(client).getId());
-		
+
 		client.withIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE, "9c4260f2-d296-4af1-b771-debda1b6cfd1").withIdentifier(
-		    "ZEIR_ID", "218220-2");
+				"ZEIR_ID", "218220-2");
 		assertEquals("05934ae338431f28bf6793b24159c647", clientService.findClient(client).getId());
-		
+
 		client = new Client("");
 		client.withIdentifier("ZEIR_ID", "218220-211");
 		assertNull(clientService.findClient(client));
-		
+
 		client.withBaseEntityId("3423fdsf-23423-hjh23423");
-		
+
 		assertNull(clientService.findClient(client));
-		
+
 		client = new Client("");
 		assertNull(clientService.findClient(client));
-		
+
 		client.withIdentifier("ZEIR_ID", "218225-1");
 		assertEquals("05934ae338431f28bf6793b24167817d", clientService.findClient(client).getId());
 	}
-	
+
 	@Test
 	public void testFind() {
 		assertEquals("05934ae338431f28bf6793b24159c647", clientService.find("33d9a17f-d729-4276-9891-b43e8b60fd12").getId());
-		
+
 		assertNull(clientService.find("3423fdsf-23423-hjh23423"));
 	}
-	
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testUpdateClientNewClient() throws JSONException {
 		Client client = new Client("33d9a17f-d729-4276-9891-b43e8b60fd12");
 		clientService.updateClient(client);
 	}
-	
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testUpdateClientClientNotExists() throws JSONException {
 		Client client = clientService.find("67007c17-97bb-4732-a1b8-3a0c292b5432");
@@ -114,92 +116,92 @@ public class ClientServiceTest extends BaseRepositoryTest {
 		client.setFirstName("Conses");
 		clientService.updateClient(client);
 	}
-	
+
 	@Test()
 	public void testUpdateClient() throws JSONException {
 		Client client = clientService.find("67007c17-97bb-4732-a1b8-3a0c292b5432");
 		client.withFirstName("Conses").withMiddleName("Divens")
-		        .withIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE, "2321312-dsfsd");
+				.withIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE, "2321312-dsfsd");
 		clientService.updateClient(client);
-		
+
 		Client updatedClient = clientService.find("67007c17-97bb-4732-a1b8-3a0c292b5432");
 		assertEquals("Conses", updatedClient.getFirstName());
 		assertEquals("Divens", updatedClient.getMiddleName());
 		assertEquals("2321312-dsfsd", updatedClient.getIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE));
 	}
-	
+
 	@Test
 	public void testMergeClient() {
 		Client client = clientService.find("cc127350-c1cd-4c3a-99d4-4d632882f522");
 		Address address = new Address().withCountry("KE").withStateProvince("Punja").withAddressType("home");
-		
+
 		client.withFirstName("Conses").withMiddleName("Divens")
-		        .withIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE, "2321312-dsfsd").withAttribute("Zone", "Zone3")
-		        .withAddress(address);
-		
+				.withIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE, "2321312-dsfsd").withAttribute("Zone", "Zone3")
+				.withAddress(address);
+
 		Client mergedClient = clientService.mergeClient(client);
 		assertEquals("Conses", mergedClient.getFirstName());
 		assertEquals("Divens", mergedClient.getMiddleName());
 		assertEquals("2321312-dsfsd", mergedClient.getIdentifier(OPENMRS_UUID_IDENTIFIER_TYPE));
 		assertEquals("Zone3", mergedClient.getAttribute("Zone"));
 		assertEquals(address, mergedClient.getAddress(address.getAddressType()));
-		
+
 	}
-	
+
 	@Test
 	public void testAddorUpdate() {
 		Client client = new Client("f67823b0-378e-4a35-93fc-bb00def74e2f").withBirthdate(new DateTime("2017-03-31"), true)
-		        .withGender("Male").withFirstName("xobili").withLastName("mbangwa");
+				.withGender("Male").withFirstName("xobili").withLastName("mbangwa");
 		client.withIdentifier("ZEIR_ID", "233864-8").withAttribute("Home_Facility", "Linda");
 		clientService.addorUpdate(client);
 		assertEquals(24, clientService.findAllClients().size());
-		
+
 		Client savedClient = clientService.find("f67823b0-378e-4a35-93fc-bb00def74e2f");
 		assertNotNull(savedClient.getId());
 		assertEquals(new DateTime("2017-03-31"), client.getBirthdate());
 		assertEquals("xobili", client.getFirstName());
 		assertEquals("mbangwa", client.getLastName());
 		assertEquals("233864-8", client.getIdentifier("ZEIR_ID"));
-		
+
 		//test adding existing client is updated
 		DateTime timeBeforeUpdate = new DateTime();
 		savedClient.withMiddleName("Rustus");
 		clientService.addorUpdate(savedClient);
-		
+
 		Client updatedClient = clientService.find(savedClient.getBaseEntityId());
 		assertEquals("Rustus", updatedClient.getMiddleName());
 		assertEquals(ClientsRepositoryImpl.REVISION_PREFIX + 2, updatedClient.getRevision());
 		assertTrue(timeBeforeUpdate.isBefore(updatedClient.getDateEdited()));
 	}
-	
+
 	@Test
 	public void testAddorUpdateWithServerVersionFlag() {
 		Client client = new Client("f67823b0-378e-4a35-93fc-bb00def74e2f").withBirthdate(new DateTime("2017-03-31"), true)
-		        .withGender("Male").withFirstName("xobili").withLastName("mbangwa");
+				.withGender("Male").withFirstName("xobili").withLastName("mbangwa");
 		client.withIdentifier("ZEIR_ID", "233864-8").withAttribute("Home_Facility", "Linda");
 		clientService.addorUpdate(client, false);
 		assertEquals(24, clientService.findAllClients().size());
-		
+
 		Client savedClient = clientService.find("f67823b0-378e-4a35-93fc-bb00def74e2f");
 		assertNotNull(savedClient.getId());
 		assertEquals(new DateTime("2017-03-31"), client.getBirthdate());
 		assertEquals("xobili", client.getFirstName());
 		assertEquals("mbangwa", client.getLastName());
 		assertEquals("233864-8", client.getIdentifier("ZEIR_ID"));
-		
+
 		long existingServerVesion = savedClient.getServerVersion();
 		//test adding existing client is updated
 		DateTime timeBeforeUpdate = new DateTime();
 		savedClient.withMiddleName("Rustus");
 		clientService.addorUpdate(savedClient, false);
-		
+
 		Client updatedClient = clientService.find(savedClient.getBaseEntityId());
 		assertEquals("Rustus", updatedClient.getMiddleName());
 		assertEquals(ClientsRepositoryImpl.REVISION_PREFIX + 2, updatedClient.getRevision());
 		assertTrue(timeBeforeUpdate.isBefore(updatedClient.getDateEdited()));
 		assertNotEquals(existingServerVesion, updatedClient.getServerVersion().longValue());
 		assertNotNull(updatedClient.getServerVersion());
-		
+
 		clientService.addorUpdate(savedClient, true);
 		assertNotNull(clientService.find(savedClient.getBaseEntityId()).getServerVersion());
 	}
@@ -211,9 +213,35 @@ public class ClientServiceTest extends BaseRepositoryTest {
 		client.setClientType("test-client-type");
 		client.setLocationId("test-location-id");
 		clientService.addClient(client);
-		List<Client> clients = clientService.findByClientTypeAndLocationId("test-client-type","test-location-id");
+		List<Client> clients = clientService.findByClientTypeAndLocationId("test-client-type", "test-location-id");
 		assertEquals(1, clients.size());
 		assertEquals("f67823b0-378e-4a35-93fc-bb00def75e2f", clients.get(0).getBaseEntityId());
 	}
-	
+
+	@Test
+	public void testFindAllByIdentifier() {
+		List<Client> clients = clientService.findAllByIdentifier("ZEIR_ID", "218221-0");
+		assertEquals(2, clients.size());
+	}
+
+	@Test
+	public void testFindByRelationship() {
+		List<Client> clients = clientService.findByRelationship("d0ecee83-6ccd-4096-9188-f63a40fa2f63");
+		assertNotNull(clients);
+		assertEquals("33d9a17f-d729-4276-9891-b43e8b60fd12", clients.get(0).getBaseEntityId());
+	}
+
+	@Test
+	public void testFindByRelationshipIdAndType() {
+		List<Client> clients = clientService.findByRelationshipIdAndType("mother", "d0ecee83-6ccd-4096-9188-f63a40fa2f63");
+		assertNotNull(clients);
+		assertEquals("33d9a17f-d729-4276-9891-b43e8b60fd12", clients.get(0).getBaseEntityId());
+	}
+
+	@Test
+	public void testFindAllByAttribute() {
+		List<Client> clients = clientService.findAllByAttribute("Father_NRC_Number","721345/67/8");
+		assertNotNull(clients);
+		assertEquals("86c039a2-0b68-4166-849e-f49897e3a510", clients.get(0).getBaseEntityId());
+	}
 }

--- a/src/test/java/org/opensrp/service/EventServiceTest.java
+++ b/src/test/java/org/opensrp/service/EventServiceTest.java
@@ -235,7 +235,7 @@ public class EventServiceTest extends BaseRepositoryTest {
 
 		Event outOfAreaEvent = eventService.processOutOfArea(event);
 		assertEquals(event, outOfAreaEvent);
-		assertEquals(22, eventService.getAll().size());
+		assertEquals(21, eventService.getAll().size());
 		
 		//Test with card identifier type. Should not create any service because there is no client with that identifier
 		event = new Event().withEventType("Out of Area Service - Vaccination").withProviderId("tester112")
@@ -244,7 +244,7 @@ public class EventServiceTest extends BaseRepositoryTest {
 		outOfAreaEvent = eventService.processOutOfArea(event);
 		assertNotNull(outOfAreaEvent);
 		assertEquals(event, outOfAreaEvent);
-		assertEquals(22, eventService.getAll().size());
+		assertEquals(21, eventService.getAll().size());
 		
 		Obs obs = new Obs("concept", "decimal", "1730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", null, "3.5", null, "weight");
 		event = new Event().withEventType("Out of Area Service - Growth Monitoring")
@@ -254,7 +254,7 @@ public class EventServiceTest extends BaseRepositoryTest {
 		outOfAreaEvent = eventService.processOutOfArea(event);
 		assertEquals(event, outOfAreaEvent);
 		
-		assertEquals(23, eventService.getAll().size());
+		assertEquals(21, eventService.getAll().size());
 		
 	}
 

--- a/src/test/java/org/opensrp/service/EventServiceTest.java
+++ b/src/test/java/org/opensrp/service/EventServiceTest.java
@@ -176,7 +176,33 @@ public class EventServiceTest extends BaseRepositoryTest {
 		eventService.addEvent(event,username);
 		assertNull(eventService.findByFormSubmissionId(event.getFormSubmissionId()));
 	}
-	
+
+	@Test
+	public void testAddEventOutOfCatchment() {
+		Obs obs = new Obs("concept", "decimal", "1730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", null, "3.5", null, "weight");
+		Event event = new Event().withBaseEntityId("435534534543").withEventType("Growth Monitoring")
+				.withFormSubmissionId("gjhg34534 nvbnv3345345__4").withEventDate(new DateTime()).withObs(obs);
+		PlanDefinition plan = new PlanDefinition();
+		plan.setIdentifier("identifier");
+
+		when(planRepository.get(anyString())).thenReturn(plan);
+		Mockito.doNothing().when(taskGenerator).processPlanEvaluation(any(PlanDefinition.class), anyString(), any(Event.class));
+		eventService.addEvent(event, username);
+
+		event = eventService.findByFormSubmissionId("gjhg34534 nvbnv3345345__4");
+		assertEquals("435534534543", event.getBaseEntityId());
+		assertEquals("Growth Monitoring", event.getEventType());
+		assertEquals(1, event.getObs().size());
+		assertEquals("3.5", event.getObs(null, "1730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA").getValue());
+
+		//test if an event with voided date add event as deleted
+		event = new Event().withBaseEntityId("2423nj-sdfsd-sf2dfsd-2399d").withEventType("Vaccination")
+				.withFormSubmissionId("hshj2342_jsjs-jhjsdfds-23").withEventDate(new DateTime()).withObs(obs);
+		event.setDateVoided(new DateTime());
+		eventService.addEventOutOfCatchment(event, username);
+		assertNull(eventService.findByFormSubmissionId(event.getFormSubmissionId()));
+	}
+
 	@Test(expected = IllegalArgumentException.class)
 	public void testAddEventForExistingEvent() {
 		Event event = eventService.findById("05934ae338431f28bf6793b241bdc44a");

--- a/src/test/java/org/opensrp/service/EventServiceTest.java
+++ b/src/test/java/org/opensrp/service/EventServiceTest.java
@@ -593,4 +593,11 @@ public class EventServiceTest extends BaseRepositoryTest {
 		exportFlagProblemEventImageMetadata.setServicePointName("EPP Ambodisatrana 2");
 		return exportFlagProblemEventImageMetadata;
 	}
+
+	@Test
+	public void testFindByServerVersion() {
+		List<Event> events = eventService.findByServerVersion(0L);
+
+		assertEquals(22, events.size());
+	}
 }


### PR DESCRIPTION
Resolves issue #500 

The changes also allow for the eventListener job to function properly given that there is no authentication object sent in the request when the call is made as a cron job as compared to a rest call with an authentication header.