### PR TITLE
Csv upload directory fix for windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.12.7-SNAPSHOT</version>
+	<version>2.12.8-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/service/multimedia/BaseMultimediaFileManager.java
+++ b/src/main/java/org/opensrp/service/multimedia/BaseMultimediaFileManager.java
@@ -152,6 +152,7 @@ public abstract class BaseMultimediaFileManager implements MultimediaFileManager
                 fileExt = ".png";
                 break;
             case "text/csv":
+            case "application/vnd.ms-excel":
                 multimediaDirPath += CSV_DIR;
                 fileExt = ".csv";
                 break;

--- a/src/test/java/org/opensrp/repository/postgres/OrganizationRepositoryTest.java
+++ b/src/test/java/org/opensrp/repository/postgres/OrganizationRepositoryTest.java
@@ -355,7 +355,7 @@ public class OrganizationRepositoryTest extends BaseRepositoryTest {
 		assertEquals("304cbcd4-0850-404a-a8b1-486b02f7b84d", assignedLocations.get(0).getJurisdictionId());
 		assertEquals("7f2ae03f-9569-5535-918c-9d976b3ae5f8", assignedLocations.get(0).getPlanId());
 		assertEquals("2019-09-10", dateFormat.format(assignedLocations.get(0).getFromDate()));
-		assertEquals("2021-09-10", dateFormat.format(assignedLocations.get(0).getToDate()));
+		assertEquals("5021-09-10", dateFormat.format(assignedLocations.get(0).getToDate()));
 		
 	}
 	
@@ -370,7 +370,7 @@ public class OrganizationRepositoryTest extends BaseRepositoryTest {
 		assertEquals("304cbcd4-0850-404a-a8b1-486b02f7b84d", assignedLocations.get(0).getJurisdictionId());
 		assertEquals("7f2ae03f-9569-5535-918c-9d976b3ae5f8", assignedLocations.get(0).getPlanId());
 		assertEquals("2019-09-10", dateFormat.format(assignedLocations.get(0).getFromDate()));
-		assertEquals("2021-09-10", dateFormat.format(assignedLocations.get(0).getToDate()));
+		assertEquals("5021-09-10", dateFormat.format(assignedLocations.get(0).getToDate()));
 		
 		assignedLocations = organizationRepository.findAssignedLocations(Arrays.asList(1l, 2l), true);
 		assertEquals(3, assignedLocations.size());

--- a/src/test/resources/test-scripts/organization.sql
+++ b/src/test/resources/test-scripts/organization.sql
@@ -23,6 +23,6 @@ INSERT INTO core.plan (identifier, json, date_deleted, server_version, id) VALUE
 INSERT INTO core.plan (identifier, json, date_deleted, server_version, id) VALUES ('7f2ae03f-9569-5535-918c-9d976b3ae5f8', '{}', null, 1567765433007, 294);
 
 
-INSERT INTO team.organization_location (id, organization_id, location_id, plan_id, from_date, to_date,duration) VALUES (1, 1, 2243, 162, '2019-09-10 17:29:55.059000', '2021-09-10 17:29:55.059000',daterange('2019-09-10','2021-09-10'));
-INSERT INTO team.organization_location (id, organization_id, location_id, plan_id, from_date, to_date,duration) VALUES (2, 1, 2243, 11, '2019-09-10 17:29:55.059000', '2021-09-10 17:29:55.059000',daterange('2019-09-10','2021-09-10'));
-INSERT INTO team.organization_location (id, organization_id, location_id, plan_id, from_date, to_date,duration) VALUES (3, 2, 2243, 294, '2019-09-10 17:29:55.059000', '2021-09-10 17:29:55.059000',daterange('2019-09-10','2021-09-10'));
+INSERT INTO team.organization_location (id, organization_id, location_id, plan_id, from_date, to_date,duration) VALUES (1, 1, 2243, 162, '2019-09-10 17:29:55.059000', '5021-09-10 17:29:55.059000',daterange('2019-09-10','5021-09-10'));
+INSERT INTO team.organization_location (id, organization_id, location_id, plan_id, from_date, to_date,duration) VALUES (2, 1, 2243, 11, '2019-09-10 17:29:55.059000', '5021-09-10 17:29:55.059000',daterange('2019-09-10','5021-09-10'));
+INSERT INTO team.organization_location (id, organization_id, location_id, plan_id, from_date, to_date,duration) VALUES (3, 2, 2243, 294, '2019-09-10 17:29:55.059000', '5021-09-10 17:29:55.059000',daterange('2019-09-10','5021-09-10'));


### PR DESCRIPTION
CSV files uploaded using a Windows machine are ending up in the `unknown_files` directory. This leads to failure when trying to download these files