### PR TITLE
Update assigned location and plans fetch size

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.12.12-SNAPSHOT</version>
+	<version>2.12.13-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/repository/postgres/OrganizationRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/OrganizationRepositoryImpl.java
@@ -220,6 +220,7 @@ public class OrganizationRepositoryImpl extends BaseRepositoryImpl<Organization>
 		OrganizationLocationExample example = new OrganizationLocationExample();
 		example.createCriteria().andOrganizationIdIn(organizationIds).andFromDateLessThanOrEqualTo(currentDate);
 		AssignedLocationAndPlanSearchBean assignedLocationAndPlanSearchBean = new AssignedLocationAndPlanSearchBean();
+		assignedLocationAndPlanSearchBean.setPageSize(Integer.MAX_VALUE);
 		Pair<Integer,Integer> pageSizeAndOffset = RepositoryUtil.getPageSizeAndOffset(assignedLocationAndPlanSearchBean);
 		return organizationLocationMapper.findAssignedlocationsAndPlans(assignedLocationAndPlanSearchBean,
 				pageSizeAndOffset.getRight(), pageSizeAndOffset.getLeft(), example.getOredCriteria(),currentDate);


### PR DESCRIPTION
Related to https://github.com/opensrp/opensrp-server-web/issues/1002

The `findAssignedLocations` defaults to a page size of 1000 which does not work for teams that have over 1k team assignments. This causes authentication failure for users that belong to such teams.