### PR TITLE
add threadpooltaskexecutor bean

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.12.13-SNAPSHOT</version>
+	<version>2.12.14-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/config/ThreadPoolExecutorConfig.java
+++ b/src/main/java/org/opensrp/config/ThreadPoolExecutorConfig.java
@@ -1,0 +1,29 @@
+package org.opensrp.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class ThreadPoolExecutorConfig {
+
+	@Value("#{opensrp['thread.pool.core.size'] ?: 5 }")
+	private int threadPoolCoreSize;
+
+	@Value("#{opensrp['thread.pool.max.size'] ?: 10 }")
+	private int threadPoolMaxSize;
+
+	@Value("#{opensrp['thread.pool.queue.capacity'] ?: 25 }")
+	private int threadPoolQueueCapacity;
+
+	@Bean
+	public ThreadPoolTaskExecutor taskExecutor() {
+		ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
+		threadPoolTaskExecutor.setCorePoolSize(threadPoolCoreSize);
+		threadPoolTaskExecutor.setMaxPoolSize(threadPoolMaxSize);
+		threadPoolTaskExecutor.setQueueCapacity(threadPoolQueueCapacity);
+		return threadPoolTaskExecutor;
+	}
+
+}

--- a/src/test/java/org/opensrp/config/ThreadPoolExecutorConfigTest.java
+++ b/src/test/java/org/opensrp/config/ThreadPoolExecutorConfigTest.java
@@ -1,0 +1,32 @@
+package org.opensrp.config;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.powermock.reflect.internal.WhiteboxImpl;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+public class ThreadPoolExecutorConfigTest {
+
+	private ThreadPoolExecutorConfig poolExecutorConfig;
+
+	@Before
+	public void setUp() {
+		poolExecutorConfig = new ThreadPoolExecutorConfig();
+	}
+
+	@Test
+	public void testTaskExecutorShouldReturnTaskExecutor() {
+		int threadPoolCoreSize = 3;
+		int threadPoolMaxSize = 4;
+		WhiteboxImpl.setInternalState(poolExecutorConfig, "threadPoolCoreSize", threadPoolCoreSize);
+		WhiteboxImpl.setInternalState(poolExecutorConfig, "threadPoolMaxSize", threadPoolMaxSize);
+
+		ThreadPoolTaskExecutor taskExecutor = poolExecutorConfig.taskExecutor();
+		assertNotNull(taskExecutor);
+		assertEquals(threadPoolCoreSize, taskExecutor.getCorePoolSize());
+		assertEquals(threadPoolMaxSize, taskExecutor.getMaxPoolSize());
+	}
+}


### PR DESCRIPTION
This change provides a threadpooltaskexecutor bean that can be used as singleton instead of initializing Executor service when needed. This will prevent multiple executor service from being created.