### PR TITLE
Security patches

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>3.0.7-SNAPSHOT</version>
+	<version>3.0.8-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>
@@ -14,8 +14,8 @@
 		<main.basedir>${project.basedir}</main.basedir>
 		<spring.version>5.2.4.RELEASE</spring.version>
 		<spring.data.version>2.2.4.RELEASE</spring.data.version>
-		<spring.security.version>5.2.11.RELEASE</spring.security.version>
-		<mybatis.version>3.5.6</mybatis.version>
+		<spring.security.version>5.2.13.RELEASE</spring.security.version>
+		<mybatis.version>3.5.7</mybatis.version>
 		<mybatis.spring.version>2.0.3</mybatis.spring.version>
 		<hibernate.version>5.4.12.Final</hibernate.version>
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
@@ -309,7 +309,7 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.20.Final</version>
+			<version>6.0.22.Final</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-joda -->
 		<dependency>


### PR DESCRIPTION
**Security patches**
 
- Bump log4j-core from 2.14.0 to 2.15.0  dependencies 
- Bump log4j-api from 2.14.0 to 2.15.0  dependencies 
- Bump spring-security-core from 5.2.2.RELEASE to 5.2.13.RELEASE dependencies 
- Bump hibernate-validator from 6.0.18.Final to 6.0.22.Final  dependencies 
- Bump httpclient from 4.5.2 to 4.5.13  dependencies 
- Bump mybatis from 3.5.4 to 3.5.7  dependencies