### PR TITLE
   Bump up server core artifact version to 2.12.17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.12.16-SNAPSHOT</version>
+	<version>2.12.17-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>
@@ -14,7 +14,7 @@
 		<main.basedir>${project.basedir}</main.basedir>
 		<spring.version>5.2.4.RELEASE</spring.version>
 		<spring.data.version>2.2.4.RELEASE</spring.data.version>
-		<mybatis.version>3.5.4</mybatis.version>
+		<mybatis.version>3.5.7</mybatis.version>
 		<mybatis.spring.version>2.0.3</mybatis.spring.version>
 		<hibernate.version>5.4.12.Final</hibernate.version>
 		<opensrp.updatePolicy>always</opensrp.updatePolicy>
@@ -196,7 +196,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.5.2</version>
+			<version>4.5.13</version>
 		</dependency>
 		<dependency>
 			<groupId>org.apache.commons</groupId>
@@ -301,7 +301,7 @@
 		<dependency>
 			<groupId>org.hibernate.validator</groupId>
 			<artifactId>hibernate-validator</artifactId>
-			<version>6.0.18.Final</version>
+			<version>6.0.22.Final</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.datatype/jackson-datatype-joda -->
 		<dependency>
@@ -319,7 +319,7 @@
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.14.0</version>
+			<version>2.15.0</version>
 		  </dependency>
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -324,7 +324,7 @@
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.14.0</version>
+			<version>2.15.0</version>
 		  </dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
**Migrate dependencies (Security Patch)**

- Bump log4j-core from 2.14.0 to 2.15.0 dependencies
- Bump log4j-api from 2.14.0 to 2.15.0 dependencies 
- Bump hibernate-validator from 6.0.18.Final to 6.0.22.Final dependencies
- Bump httpclient from 4.5.2 to 4.5.13 dependencies
- Bump mybatis from 3.5.4 to 3.5.7 dependencies
