### PR TITLE
Log4j security patch v2.16 - v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.12.18-SNAPSHOT</version>
+	<version>2.12.19-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>
@@ -319,12 +319,12 @@
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.15.0</version>
+			<version>2.16.0</version>
 		  </dependency>
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.15.0</version>
+			<version>2.16.0</version>
 		  </dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
Fixes [vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2021-45046). 