### PR TITLE
update log4j version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.12.20-SNAPSHOT</version>
+	<version>2.12.21-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>
@@ -319,12 +319,12 @@
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-api</artifactId>
-			<version>2.16.0</version>
+			<version>2.17.0</version>
 		  </dependency>
 		  <dependency>
 			<groupId>org.apache.logging.log4j</groupId>
 			<artifactId>log4j-core</artifactId>
-			<version>2.16.0</version>
+			<version>2.17.0</version>
 		  </dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
Fixes [CVE-2021-45105](https://nvd.nist.gov/vuln/detail/CVE-2021-45105) vulnerability.