### PR TITLE
validate root location for empty or null parentid

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>2.13.1-SNAPSHOT</version>
+	<version>2.13.2-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/service/PhysicalLocationService.java
+++ b/src/main/java/org/opensrp/service/PhysicalLocationService.java
@@ -130,8 +130,13 @@ public class PhysicalLocationService {
 		Set<String> locationsWithErrors = new HashSet<>();
 		for (PhysicalLocation location : locations) {
 			try {
-				location.setJurisdiction(isJurisdiction);
-				addOrUpdate(location);
+				if(location.getProperties().getGeographicLevel()==0 && !StringUtils.isEmpty(location.getProperties().getParentId())){
+					System.out.println("I am inside with location  ");
+					locationsWithErrors.add(location.getId());
+				} else {
+					location.setJurisdiction(isJurisdiction);
+					addOrUpdate(location);
+				}
 			}
 			catch (Exception e) {
 				logger.error(e.getMessage(), e);


### PR DESCRIPTION
A root location that has a parentId can cause the team assignment query run endlessly as described [here](https://github.com/opensrp/opensrp-server-web/issues/1049). 