### PR TITLE
Bug Fix: Handle Missing baseEntityId in Event JSON for Save

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<artifactId>opensrp-server-core</artifactId>
 	<packaging>jar</packaging>
-	<version>3.2.4-SNAPSHOT</version>
+	<version>3.2.5-SNAPSHOT</version>
 	<name>opensrp-server-core</name>
 	<description>OpenSRP Server Core module</description>
 	<url>https://github.com/OpenSRP/opensrp-server-core</url>

--- a/src/main/java/org/opensrp/repository/postgres/EventsRepositoryImpl.java
+++ b/src/main/java/org/opensrp/repository/postgres/EventsRepositoryImpl.java
@@ -51,7 +51,7 @@ public class EventsRepositoryImpl extends BaseRepositoryImpl<Event> implements E
 	@Override
 	public void add(Event entity) {
 		if (entity == null || entity.getBaseEntityId() == null) {
-			return;
+			throw new IllegalArgumentException("Empty event or missing baseEntityId");
 		}
 		
 		if (retrievePrimaryKey(entity) != null) { // Event already added

--- a/src/main/java/org/opensrp/service/EventService.java
+++ b/src/main/java/org/opensrp/service/EventService.java
@@ -253,7 +253,9 @@ public class EventService {
 	 */
 	public synchronized Event processOutOfArea(Event event) {
 		try {
-			String programClientId = event.getDetails().getOrDefault("program_client_id", "");
+			String programClientId = event.getDetails() != null
+					? event.getDetails().getOrDefault("program_client_id", "")
+					: "";
 
 			String identifier = StringUtils.isBlank(event.getIdentifier(Client.ZEIR_ID))
 					? (StringUtils.isBlank(event.getIdentifier(OPENSRP_ID)) ? programClientId : event.getIdentifier(OPENSRP_ID))

--- a/src/test/java/org/opensrp/service/EventServiceTest.java
+++ b/src/test/java/org/opensrp/service/EventServiceTest.java
@@ -261,7 +261,7 @@ public class EventServiceTest extends BaseRepositoryTest {
 
 		Event outOfAreaEvent = eventService.processOutOfArea(event);
 		assertEquals(event, outOfAreaEvent);
-		assertEquals(21, eventService.getAll().size());
+		assertEquals(22, eventService.getAll().size());
 		
 		//Test with card identifier type. Should not create any service because there is no client with that identifier
 		event = new Event().withEventType("Out of Area Service - Vaccination").withProviderId("tester112")
@@ -270,7 +270,7 @@ public class EventServiceTest extends BaseRepositoryTest {
 		outOfAreaEvent = eventService.processOutOfArea(event);
 		assertNotNull(outOfAreaEvent);
 		assertEquals(event, outOfAreaEvent);
-		assertEquals(21, eventService.getAll().size());
+		assertEquals(22, eventService.getAll().size());
 		
 		Obs obs = new Obs("concept", "decimal", "1730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", null, "3.5", null, "weight");
 		event = new Event().withEventType("Out of Area Service - Growth Monitoring")
@@ -280,7 +280,7 @@ public class EventServiceTest extends BaseRepositoryTest {
 		outOfAreaEvent = eventService.processOutOfArea(event);
 		assertEquals(event, outOfAreaEvent);
 		
-		assertEquals(21, eventService.getAll().size());
+		assertEquals(23, eventService.getAll().size());
 		
 	}
 

--- a/src/test/java/org/opensrp/service/EventServiceTest.java
+++ b/src/test/java/org/opensrp/service/EventServiceTest.java
@@ -253,35 +253,52 @@ public class EventServiceTest extends BaseRepositoryTest {
 	}
 	
 	@Test
-	public void testProcessOutOfArea() throws SQLException {
-		scripts.add("client.sql");
+	public void testProcessOutOfAreaDoesNotAddOutOfCatchmentEventWhenClientIdentifierIsInvalid() throws SQLException {
 		populateDatabase();
-		Event event = new Event().withEventType("Out of Area Service - Vaccination").withProviderId("tester111")
-		        .withLocationId("2242342-23dsfsdfds").withIdentifier(Client.ZEIR_ID, "218229-3");
 
+		Event event = new Event().withEventType("Out of Area Service - Vaccination")
+				.withProviderId("tester112")
+				.withLocationId("2242342-23dsfsdfds")
+				.withIdentifier(Client.ZEIR_ID, "c_2182291985");
+
+		int prevCount = eventService.getAll().size();
 		Event outOfAreaEvent = eventService.processOutOfArea(event);
-		assertEquals(event, outOfAreaEvent);
-		assertEquals(22, eventService.getAll().size());
-		
-		//Test with card identifier type. Should not create any service because there is no client with that identifier
-		event = new Event().withEventType("Out of Area Service - Vaccination").withProviderId("tester112")
-		        .withLocationId("2242342-23dsfsdfds").withIdentifier(Client.ZEIR_ID, "c_2182291985");
-
-		outOfAreaEvent = eventService.processOutOfArea(event);
 		assertNotNull(outOfAreaEvent);
 		assertEquals(event, outOfAreaEvent);
-		assertEquals(22, eventService.getAll().size());
-		
-		Obs obs = new Obs("concept", "decimal", "1730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", null, "3.5", null, "weight");
-		event = new Event().withEventType("Out of Area Service - Growth Monitoring")
-		        .withFormSubmissionId("gjhg34534 nvbnv3345345__4").withEventDate(new DateTime()).withObs(obs)
-		        .withIdentifier(Client.ZEIR_ID, "218229-3");
-		
-		outOfAreaEvent = eventService.processOutOfArea(event);
+		assertEquals(prevCount, eventService.getAll().size());
+	}
+
+	@Test
+	public void testProcessOutOfAreaAddsOutOfCatchmentVaccinationEventWhenEventHasValidClientIdentifier() throws SQLException {
+		populateDatabase();
+
+		Event event = new Event()
+				.withEventType("Out of Area Service - Vaccination")
+				.withProviderId("tester111")
+		        .withLocationId("2242342-23dsfsdfds")
+				.withIdentifier(Client.ZEIR_ID, "218229-3");
+
+		int prevCount = eventService.getAll().size();
+		Event outOfAreaEvent = eventService.processOutOfArea(event);
 		assertEquals(event, outOfAreaEvent);
-		
-		assertEquals(23, eventService.getAll().size());
-		
+		assertEquals(prevCount + 1, eventService.getAll().size());
+	}
+
+	@Test
+	public void testProcessOutOfAreaAddsOutOfCatchmentGrowthMonitoringEventWhenEventHasValidClientIdentifier() throws SQLException {
+		populateDatabase();
+
+		Obs obs = new Obs("concept", "decimal", "1730AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", null, "3.5", null, "weight");
+		Event event = new Event()
+				.withEventType("Out of Area Service - Growth Monitoring")
+				.withFormSubmissionId("gjhg34534 nvbnv3345345__4")
+				.withEventDate(new DateTime()).withObs(obs)
+				.withIdentifier(Client.ZEIR_ID, "218229-3");
+
+		int prevCount = eventService.getAll().size();
+		Event outOfAreaEvent = eventService.processOutOfArea(event);
+		assertEquals(event, outOfAreaEvent);
+		assertEquals(prevCount + 1, eventService.getAll().size());
 	}
 
 	@Test


### PR DESCRIPTION
Resolves issue #589 

- [x] Handle Empty Event or Missing baseEntityId During Event Save
- [x] Handle Missing Details Field in Event When Processing outOfArea Event